### PR TITLE
Keep other 3th party repos enabled as much as possible

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -28,6 +28,9 @@ use esmith::Build::CreateLinks qw(:all);
 
 event_actions("nethserver-mrmarkuz-update", qw(
     initialize-default-databases        00
-    mrmarkuz_enablerepo                 10
+));
+
+event_templates(("nethserver-mrmarkuz-update", qw(
+    /etc/nethserver/eorepo.conf
 ));
 

--- a/root/etc/e-smith/events/actions/mrmarkuz_enablerepo
+++ b/root/etc/e-smith/events/actions/mrmarkuz_enablerepo
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo '[NOTICE] applying new YUM repository configuration for mrmarkuz repo'
-exec /sbin/e-smith/signal-event software-repos-save


### PR DESCRIPTION
- Omit running signal-event software-repos-save explicitly

One does not need to run signal-event software-repos-save to install and enable the required repo.
Running software-repos-save often confuses people, especially on non-subscription, as it disables all repositories not listed in /etc/nethserver/eorepo.conf

( this is the last one at your repositories :) )